### PR TITLE
Wip store waypoints locally

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,20 +1,25 @@
 import { registerRootComponent } from "expo";
+import { NativeRouter } from "react-router-native";
 
 import Main from "./components/main";
 import IdStorage from "./utils/id-storage";
+import WaypointStorage from "./utils/waypoint-storage";
 import UserIdStorageContext from "./contexts/user-id-context";
 import RouteIdStorageContext from "./contexts/route-id-context";
-import { NativeRouter } from "react-router-native";
+import WaypointStorageContext from "./contexts/waypoint-context";
 
 const userIdStorage = new IdStorage("user-id");
 const routeIdStorage = new IdStorage("route-id");
+const waypointStorage = new WaypointStorage("waypoint");
 
 const App = () => {
 	return (
 		<NativeRouter>
 			<UserIdStorageContext.Provider value={userIdStorage}>
 				<RouteIdStorageContext.Provider value={routeIdStorage}>
-					<Main />
+					<WaypointStorageContext.Provider value={waypointStorage}>
+						<Main />
+					</WaypointStorageContext.Provider>
 				</RouteIdStorageContext.Provider>
 			</UserIdStorageContext.Provider>
 		</NativeRouter>

--- a/src/contexts/waypoint-context.ts
+++ b/src/contexts/waypoint-context.ts
@@ -1,0 +1,5 @@
+import React from "react";
+
+const WaypointStorageContext = React.createContext(undefined);
+
+export default WaypointStorageContext;

--- a/src/hooks/use-waypoint-storage.ts
+++ b/src/hooks/use-waypoint-storage.ts
@@ -1,0 +1,9 @@
+import { useContext } from "react";
+
+import WaypointStorageContext from "../contexts/waypoint-context";
+
+const useWaypointStorage = () => {
+	return useContext(WaypointStorageContext);
+};
+
+export default useWaypointStorage;

--- a/src/screens/map-screen.tsx
+++ b/src/screens/map-screen.tsx
@@ -18,7 +18,7 @@ const MapScreen = () => {
 	const [mobileNetCode, setMobileNetCode] = useState<string | null>(null);
 	const [routeCoordinates, setRouteCoordinates] = useState<Array<LatLng>>([]);
 	const [showRoute, setShowRoute] = useState<boolean>(true);
-	const [trackingInterval] = useState<number>(1000);
+	const [trackingInterval] = useState<number>(2500);
 	const [isTracking, setIsTracking] = useState<boolean>(false);
 	const [userId, setUserId] = useState<string | null>(null);
 	const [routeId, setRouteId] = useState<string | null>(null);

--- a/src/utils/waypoint-storage.ts
+++ b/src/utils/waypoint-storage.ts
@@ -1,0 +1,52 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { LocationObject } from "expo-location";
+
+interface Waypoint {
+	routeId: string;
+	location: LocationObject;
+	mnc: string | null;
+}
+
+class WaypointStorage {
+	namespace: string;
+	constructor(namespace = "waypoint") {
+		this.namespace = namespace;
+	}
+
+	async getWaypoints() {
+		console.log(`getting existing waypoints...`);
+		try {
+			const existingWaypoints = await AsyncStorage.getItem(
+				`${this.namespace}.waypoints`
+			);
+			return existingWaypoints ? JSON.parse(existingWaypoints) : [];
+		} catch (error) {
+			console.log(error);
+		}
+	}
+
+	async addWaypoint(waypointObject: Waypoint) {
+		console.log(`storing new waypoint into the storage...`);
+		try {
+			const existingWaypoints = await this.getWaypoints();
+			const updatedWaypoints = [...existingWaypoints, waypointObject];
+			await AsyncStorage.setItem(
+				`${this.namespace}.waypoints`,
+				JSON.stringify(updatedWaypoints)
+			);
+		} catch (error) {
+			console.log(error);
+		}
+	}
+
+	async clearWaypoints() {
+		console.log(`waypoints has been removed from the storage...`);
+		try {
+			await AsyncStorage.removeItem(`${this.namespace}.waypoints`);
+		} catch (error) {
+			console.log(error);
+		}
+	}
+}
+
+export default WaypointStorage;


### PR DESCRIPTION
To store waypoint into local device in a same manner than previously created `user ID` and `route ID`:

- `utils/waypoint-storage.ts` -file has been created which handles operations to get, set and remove waypoints.
- `hooks/use-routes.ts` -file has been modified so that waypoints will be stored along with other functionalities

I tried to keep other functionalities as much as possible untouched. Only tracking interval has been changed from 1 second to 2,5 seconds in order to reduce `console.log` spam. Currently storing waypoints into local storage does not give any benefits for the application ie. there is no implementation to retrieve them. Later on, it could be useful to retrieve waypoints and continue route tracking when application has been accidentally or even intentionally restarted during offline conditions.