### PR TITLE
Wip interval for waypointlist sending

### DIFF
--- a/src/hooks/use-routes.ts
+++ b/src/hooks/use-routes.ts
@@ -1,4 +1,3 @@
-import { LocationObject } from "expo-location";
 import {
 	startNewRoute,
 	sendNewWaypoint,
@@ -31,22 +30,11 @@ const useRoutes = () => {
 	/**
 	 * Function to add new waypoints to current route. Makes http request
 	 * to add location and mnc-code to given routeId and stores waypoint into local device.
-	 * TODO: Add timestamps to http request.
 	 * @returns request response
 	 */
-	const sendWaypoint = async (
-		routeId: string,
-		location: LocationObject,
-		mnc: string
-	) => {
-		const data = await sendNewWaypoint(routeId, location, mnc);
-		// Needs timestamp as well
-		const waypoint = {
-			routeId,
-			location,
-			mnc,
-		};
-		await waypointStorage.addWaypoint(waypoint);
+	const sendWaypoint = async (waypointList) => {
+		const data = await sendNewWaypoint(waypointList);
+		await waypointStorage.addWaypoint(waypointList);
 		return data;
 	};
 

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -1,5 +1,4 @@
 import Constants from "expo-constants";
-import { LocationObject } from "expo-location";
 
 const baseUrl = Constants.manifest.extra.uri;
 
@@ -41,20 +40,17 @@ export const startNewRoute = async (userId: string) => {
 	}
 };
 
-export const sendNewWaypoint = async (
-	routeId: string,
-	location: LocationObject,
-	mnc: string
-) => {
+export const sendNewWaypoint = async (waypointList) => {
 	const url = `${baseUrl}/create-waypoint/`;
-	const waypoint_info = [
-		{
-			route_id: routeId,
-			latitude: location.coords.latitude,
-			longitude: location.coords.longitude,
-			mnc: mnc,
-		},
-	];
+	const waypoint_info = waypointList.map((waypoint) => {
+		return {
+			route_id: waypoint.routeId,
+			latitude: waypoint.location.coords.latitude,
+			longitude: waypoint.location.coords.longitude,
+			mnc: waypoint.mobileNetCode,
+			ts: new Date(waypoint.location.timestamp),
+		};
+	});
 	const settings = {
 		method: "POST",
 		headers: {

--- a/src/utils/waypoint-storage.ts
+++ b/src/utils/waypoint-storage.ts
@@ -26,7 +26,7 @@ class WaypointStorage {
 	}
 
 	async addWaypoint(waypointObject: Waypoint) {
-		console.log(`storing new waypoint into the storage...`);
+		console.log(`storing new waypointlist into the storage...`);
 		try {
 			const existingWaypoints = await this.getWaypoints();
 			const updatedWaypoints = [...existingWaypoints, waypointObject];


### PR DESCRIPTION
- Modified POST requests to send list of waypoints instead of a single waypoint at a time
- Created a new interval for waypoint sending seperate from waypoint updating
- Gives timestamps in POST requests