### PR TITLE
Wip restart tracking on launch

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -4,7 +4,7 @@ export default {
 	name: "Berry picker tracker",
 	slug: "berry-picker-tracker",
 	entryPoint: "./index.js",
-	version: "1.0.9",
+	version: "1.0.11",
 	orientation: "portrait",
 	icon: "./assets/icon.png",
 	splash: {
@@ -19,7 +19,7 @@ export default {
 	ios: {
 		bundleIdentifier: "com.berry.picker.tracker",
 		supportsTablet: true,
-		buildNumber: "10",
+		buildNumber: "12",
 		infoPlist: {
 			UIBackgroundModes: ["location", "fetch"],
 			NSLocationAlwaysAndWhenInUseUsageDescription: "App requires geolocation",
@@ -27,7 +27,7 @@ export default {
 	},
 	android: {
 		package: "com.berry.picker.tracker",
-		versionCode: 10,
+		versionCode: 12,
 		adaptiveIcon: {
 			foregroundImage: "./assets/adaptive-icon.png",
 			backgroundColor: "#FFFFFF",

--- a/app.config.js
+++ b/app.config.js
@@ -4,7 +4,7 @@ export default {
 	name: "Berry picker tracker",
 	slug: "berry-picker-tracker",
 	entryPoint: "./index.js",
-	version: "1.0.8",
+	version: "1.0.9",
 	orientation: "portrait",
 	icon: "./assets/icon.png",
 	splash: {
@@ -19,7 +19,7 @@ export default {
 	ios: {
 		bundleIdentifier: "com.berry.picker.tracker",
 		supportsTablet: true,
-		buildNumber: "9",
+		buildNumber: "10",
 		infoPlist: {
 			UIBackgroundModes: ["location", "fetch"],
 			NSLocationAlwaysAndWhenInUseUsageDescription: "App requires geolocation",
@@ -27,16 +27,11 @@ export default {
 	},
 	android: {
 		package: "com.berry.picker.tracker",
-		versionCode: 9,
+		versionCode: 10,
 		adaptiveIcon: {
 			foregroundImage: "./assets/adaptive-icon.png",
 			backgroundColor: "#FFFFFF",
 		},
-		permissions: [
-			"ACCESS_COARSE_LOCATION",
-			"ACCESS_FINE_LOCATION",
-			"ACCESS_BACKGROUND_LOCATION",
-		],
 		config: {
 			googleMaps: {
 				apiKey: process.env.MAPS_API,

--- a/app.config.js
+++ b/app.config.js
@@ -32,6 +32,11 @@ export default {
 			foregroundImage: "./assets/adaptive-icon.png",
 			backgroundColor: "#FFFFFF",
 		},
+		permissions: [
+			"ACCESS_COARSE_LOCATION",
+			"ACCESS_FINE_LOCATION",
+			"ACCESS_BACKGROUND_LOCATION",
+		],
 		config: {
 			googleMaps: {
 				apiKey: process.env.MAPS_API,

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
 				"react-dom": "18.0.0",
 				"react-native": "0.69.6",
 				"react-native-maps": "^0.31.1",
+				"react-native-modal-selector": "^2.1.2",
+				"react-native-settings-screen": "^2.2.1",
 				"react-native-vector-icons": "^9.2.0",
 				"react-native-web": "~0.18.7",
 				"react-redux": "^8.0.4",
@@ -8058,6 +8060,14 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/camelize": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+			"integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/caniuse-lite": {
 			"version": "1.0.30001431",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
@@ -8597,6 +8607,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/core-js": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+			"integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==",
+			"deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js."
+		},
 		"node_modules/core-js-compat": {
 			"version": "3.26.1",
 			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.26.1.tgz",
@@ -8684,6 +8700,14 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/css-color-keywords": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+			"integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/css-in-js-utils": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
@@ -8692,6 +8716,21 @@
 				"hyphenate-style-name": "^1.0.2",
 				"isobject": "^3.0.1"
 			}
+		},
+		"node_modules/css-to-react-native": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
+			"integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
+			"dependencies": {
+				"camelize": "^1.0.0",
+				"css-color-keywords": "^1.0.0",
+				"postcss-value-parser": "^3.3.0"
+			}
+		},
+		"node_modules/css-to-react-native/node_modules/postcss-value-parser": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
 		},
 		"node_modules/csstype": {
 			"version": "3.1.0",
@@ -8998,6 +9037,14 @@
 			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/encoding": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+			"dependencies": {
+				"iconv-lite": "^0.6.2"
 			}
 		},
 		"node_modules/end-of-stream": {
@@ -11136,6 +11183,17 @@
 			"resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
 			"integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
 		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/ieee754": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -11847,6 +11905,24 @@
 			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
+			"dependencies": {
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
+			}
+		},
+		"node_modules/isomorphic-fetch/node_modules/node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"dependencies": {
+				"encoding": "^0.1.11",
+				"is-stream": "^1.0.1"
 			}
 		},
 		"node_modules/istanbul-lib-coverage": {
@@ -19371,6 +19447,26 @@
 				}
 			}
 		},
+		"node_modules/react-native-modal-selector": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/react-native-modal-selector/-/react-native-modal-selector-2.1.2.tgz",
+			"integrity": "sha512-+Cvoz/yNUFmfIkJ7xkmlLR2nhJOUhx00S6BPqp2Ruy8LkmaiNr7WMZ4BzsgzylyEgZ84Q+42HQ0v0QzJYobviA==",
+			"dependencies": {
+				"prop-types": "^15.5.10"
+			}
+		},
+		"node_modules/react-native-settings-screen": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/react-native-settings-screen/-/react-native-settings-screen-2.2.1.tgz",
+			"integrity": "sha512-qmcO+CJyRAbuTeON/IvJy5CCK7dXz8EopwzREhmkrg5wsUPNlZLIU0JqsicbxA4oZ0pMYA2cwPUUBAb+dmMALQ==",
+			"dependencies": {
+				"styled-components": "^3.4.9"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-native": "*"
+			}
+		},
 		"node_modules/react-native-vector-icons": {
 			"version": "9.2.0",
 			"resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-9.2.0.tgz",
@@ -21149,10 +21245,86 @@
 			"resolved": "https://registry.npmjs.org/structured-headers/-/structured-headers-0.4.1.tgz",
 			"integrity": "sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg=="
 		},
+		"node_modules/styled-components": {
+			"version": "3.4.10",
+			"resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.4.10.tgz",
+			"integrity": "sha512-TA8ip8LoILgmSAFd3r326pKtXytUUGu5YWuqZcOQVwVVwB6XqUMn4MHW2IuYJ/HAD81jLrdQed8YWfLSG1LX4Q==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"buffer": "^5.0.3",
+				"css-to-react-native": "^2.0.3",
+				"fbjs": "^0.8.16",
+				"hoist-non-react-statics": "^2.5.0",
+				"prop-types": "^15.5.4",
+				"react-is": "^16.3.1",
+				"stylis": "^3.5.0",
+				"stylis-rule-sheet": "^0.0.10",
+				"supports-color": "^3.2.3"
+			},
+			"peerDependencies": {
+				"react": ">= 0.14.0 < 17.0.0-0"
+			}
+		},
+		"node_modules/styled-components/node_modules/fbjs": {
+			"version": "0.8.18",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.18.tgz",
+			"integrity": "sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==",
+			"dependencies": {
+				"core-js": "^1.0.0",
+				"isomorphic-fetch": "^2.1.1",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^0.7.30"
+			}
+		},
+		"node_modules/styled-components/node_modules/has-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+			"integrity": "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/styled-components/node_modules/hoist-non-react-statics": {
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+		},
+		"node_modules/styled-components/node_modules/react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+		},
+		"node_modules/styled-components/node_modules/supports-color": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+			"integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
+			"dependencies": {
+				"has-flag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
 		"node_modules/styleq": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/styleq/-/styleq-0.1.2.tgz",
 			"integrity": "sha512-EBNuMVSxpssuFcJq/c4zmZ4tpCyX9E27hz5xPJhw4URjRHcYXPHh8rDHY/tJsw5gtP0+tIL3IBYeQVIYjdZFhg=="
+		},
+		"node_modules/stylis": {
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
+			"integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
+		},
+		"node_modules/stylis-rule-sheet": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
+			"integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==",
+			"peerDependencies": {
+				"stylis": "^3.5.0"
+			}
 		},
 		"node_modules/sucrase": {
 			"version": "3.25.0",
@@ -28217,6 +28389,11 @@
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
 			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
 		},
+		"camelize": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+			"integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="
+		},
 		"caniuse-lite": {
 			"version": "1.0.30001431",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
@@ -28627,6 +28804,11 @@
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw=="
 		},
+		"core-js": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+			"integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA=="
+		},
 		"core-js-compat": {
 			"version": "3.26.1",
 			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.26.1.tgz",
@@ -28697,6 +28879,11 @@
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
 			"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
 		},
+		"css-color-keywords": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+			"integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="
+		},
 		"css-in-js-utils": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
@@ -28704,6 +28891,23 @@
 			"requires": {
 				"hyphenate-style-name": "^1.0.2",
 				"isobject": "^3.0.1"
+			}
+		},
+		"css-to-react-native": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
+			"integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
+			"requires": {
+				"camelize": "^1.0.0",
+				"css-color-keywords": "^1.0.0",
+				"postcss-value-parser": "^3.3.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+				}
 			}
 		},
 		"csstype": {
@@ -28929,6 +29133,14 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
 			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
+		},
+		"encoding": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+			"requires": {
+				"iconv-lite": "^0.6.2"
+			}
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
@@ -30548,6 +30760,14 @@
 			"resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
 			"integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
 		},
+		"iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			}
+		},
 		"ieee754": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -31035,6 +31255,26 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
+			"requires": {
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
+			},
+			"dependencies": {
+				"node-fetch": {
+					"version": "1.7.3",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+					"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+					"requires": {
+						"encoding": "^0.1.11",
+						"is-stream": "^1.0.1"
+					}
+				}
+			}
 		},
 		"istanbul-lib-coverage": {
 			"version": "3.2.0",
@@ -36836,6 +37076,22 @@
 				"deprecated-react-native-prop-types": "^2.3.0"
 			}
 		},
+		"react-native-modal-selector": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/react-native-modal-selector/-/react-native-modal-selector-2.1.2.tgz",
+			"integrity": "sha512-+Cvoz/yNUFmfIkJ7xkmlLR2nhJOUhx00S6BPqp2Ruy8LkmaiNr7WMZ4BzsgzylyEgZ84Q+42HQ0v0QzJYobviA==",
+			"requires": {
+				"prop-types": "^15.5.10"
+			}
+		},
+		"react-native-settings-screen": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/react-native-settings-screen/-/react-native-settings-screen-2.2.1.tgz",
+			"integrity": "sha512-qmcO+CJyRAbuTeON/IvJy5CCK7dXz8EopwzREhmkrg5wsUPNlZLIU0JqsicbxA4oZ0pMYA2cwPUUBAb+dmMALQ==",
+			"requires": {
+				"styled-components": "^3.4.9"
+			}
+		},
 		"react-native-vector-icons": {
 			"version": "9.2.0",
 			"resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-9.2.0.tgz",
@@ -38198,10 +38454,75 @@
 			"resolved": "https://registry.npmjs.org/structured-headers/-/structured-headers-0.4.1.tgz",
 			"integrity": "sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg=="
 		},
+		"styled-components": {
+			"version": "3.4.10",
+			"resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.4.10.tgz",
+			"integrity": "sha512-TA8ip8LoILgmSAFd3r326pKtXytUUGu5YWuqZcOQVwVVwB6XqUMn4MHW2IuYJ/HAD81jLrdQed8YWfLSG1LX4Q==",
+			"requires": {
+				"buffer": "^5.0.3",
+				"css-to-react-native": "^2.0.3",
+				"fbjs": "^0.8.16",
+				"hoist-non-react-statics": "^2.5.0",
+				"prop-types": "^15.5.4",
+				"react-is": "^16.3.1",
+				"stylis": "^3.5.0",
+				"stylis-rule-sheet": "^0.0.10",
+				"supports-color": "^3.2.3"
+			},
+			"dependencies": {
+				"fbjs": {
+					"version": "0.8.18",
+					"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.18.tgz",
+					"integrity": "sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==",
+					"requires": {
+						"core-js": "^1.0.0",
+						"isomorphic-fetch": "^2.1.1",
+						"loose-envify": "^1.0.0",
+						"object-assign": "^4.1.0",
+						"promise": "^7.1.1",
+						"setimmediate": "^1.0.5",
+						"ua-parser-js": "^0.7.30"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA=="
+				},
+				"hoist-non-react-statics": {
+					"version": "2.5.5",
+					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+					"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+				},
+				"react-is": {
+					"version": "16.13.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
+					"requires": {
+						"has-flag": "^1.0.0"
+					}
+				}
+			}
+		},
 		"styleq": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/styleq/-/styleq-0.1.2.tgz",
 			"integrity": "sha512-EBNuMVSxpssuFcJq/c4zmZ4tpCyX9E27hz5xPJhw4URjRHcYXPHh8rDHY/tJsw5gtP0+tIL3IBYeQVIYjdZFhg=="
+		},
+		"stylis": {
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
+			"integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
+		},
+		"stylis-rule-sheet": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
+			"integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
 		},
 		"sucrase": {
 			"version": "3.25.0",

--- a/src/components/info-container.tsx
+++ b/src/components/info-container.tsx
@@ -6,25 +6,28 @@ import * as Cellular from "expo-cellular";
 
 import { useTypedSelector } from "../store";
 import theme from "../theme";
+import { statusBarHeight } from "../constants";
 
 const styles = StyleSheet.create({
 	infoContainer: {
 		display: "flex",
 		position: "absolute",
 		backgroundColor: theme.colors.buttonBackgroundColor,
-		top: 100,
+		top: statusBarHeight,
 		alignSelf: "flex-start",
-		marginLeft: 10,
-		borderRadius: 20,
-		padding: 15,
-		textAlign: "center",
-		height: 150,
+		borderRadius: 10,
+		padding: 10,
 		shadowColor: "black",
 		shadowOffset: { width: 3, height: 3 },
 		shadowOpacity: 0.8,
 		shadowRadius: 20,
-		elevation: 5,
-		margin: 5,
+		elevation: 10,
+		margin: 15,
+	},
+	textStyle: {
+		fontSize: 13,
+		fontWeight: "bold",
+		color: "dimgrey",
 	},
 });
 
@@ -50,21 +53,19 @@ const InfoContainer = (): JSX.Element => {
 
 	return (
 		<View style={styles.infoContainer}>
-			<Text style={{ fontWeight: "bold" }}>Current location:</Text>
-			<Text>
-				-Latitude: {curLocation === null ? "NA" : curLocation.coords.latitude}
+			<Text style={styles.textStyle}>
+				Lat: {curLocation === null ? "NA" : curLocation.coords.latitude}
 			</Text>
-			<Text>
-				-Longitude: {curLocation === null ? "NA" : curLocation.coords.longitude}
+			<Text style={styles.textStyle}>
+				Lon: {curLocation === null ? "NA" : curLocation.coords.longitude}
 			</Text>
-			<Text style={{ fontWeight: "bold" }}>Cellular network:</Text>
-			<Text>
-				-NMC code: {mobileNetCode === null ? "No network" : mobileNetCode}
+			<Text style={styles.textStyle}>
+				NMC code: {mobileNetCode === null ? "No network" : mobileNetCode}
 			</Text>
-			<Text style={{ fontWeight: "bold" }}>
+			<Text style={styles.textStyle}>
 				Local waypoints: {waypoints.localWaypoints.length}
 			</Text>
-			<Text style={{ fontWeight: "bold" }}>
+			<Text style={styles.textStyle}>
 				Pending waypoints: {waypoints.pendingWaypoints.length}
 			</Text>
 		</View>

--- a/src/components/map-view-container.tsx
+++ b/src/components/map-view-container.tsx
@@ -1,14 +1,13 @@
 import { View, StyleSheet, Dimensions } from "react-native";
 import MapView, { Polyline, UrlTile, Circle } from "react-native-maps";
 
-import { baseUrl, statusBarHeight, tileCacheDirectory } from "../constants";
+import { baseUrl, tileCacheDirectory } from "../constants";
 import { useTypedSelector } from "../store";
 
 const styles = StyleSheet.create({
 	map: {
 		width: Dimensions.get("window").width,
 		height: Dimensions.get("window").height,
-		top: statusBarHeight + 50,
 	},
 });
 

--- a/src/components/map-view-container.tsx
+++ b/src/components/map-view-container.tsx
@@ -1,13 +1,14 @@
 import { View, StyleSheet, Dimensions } from "react-native";
 import MapView, { Polyline, UrlTile, Circle } from "react-native-maps";
 
-import { baseUrl, tileCacheDirectory } from "../constants";
+import { baseUrl, statusBarHeight, tileCacheDirectory } from "../constants";
 import { useTypedSelector } from "../store";
 
 const styles = StyleSheet.create({
 	map: {
 		width: Dimensions.get("window").width,
 		height: Dimensions.get("window").height,
+		top: statusBarHeight,
 	},
 });
 
@@ -34,6 +35,7 @@ function getCircleColor(color: string): string {
  */
 const MapViewContainer = (): JSX.Element => {
 	const routeInfo = useTypedSelector((state) => state.route);
+	const mapLifetime = useTypedSelector((state) => state.user.mapLifetime);
 	const localWaypoints = useTypedSelector(
 		(state) => state.waypoints.localWaypoints
 	);
@@ -57,7 +59,7 @@ const MapViewContainer = (): JSX.Element => {
 					maximumZ={19}
 					zIndex={-3}
 					tileCachePath={tileCacheDirectory}
-					tileCacheMaxAge={172800}
+					tileCacheMaxAge={mapLifetime * 3600}
 					offlineMode={false}
 				/>
 				<Polyline

--- a/src/components/route-button.tsx
+++ b/src/components/route-button.tsx
@@ -5,7 +5,7 @@ import theme from "../theme";
 const styles = StyleSheet.create({
 	buttonIcon: {
 		backgroundColor: theme.colors.buttonBackgroundColor,
-		borderRadius: 20,
+		borderRadius: 10,
 		padding: 15,
 		textAlign: "center",
 		height: 50,
@@ -13,7 +13,7 @@ const styles = StyleSheet.create({
 		shadowOffset: { width: 3, height: 3 },
 		shadowOpacity: 0.8,
 		shadowRadius: 20,
-		elevation: 5,
+		elevation: 10,
 		margin: 5,
 	},
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,3 +10,5 @@ export const statusBarHeight: number =
 	StatusBar.currentHeight ?? Constants.statusBarHeight;
 
 export const tileCacheDirectory = FileSystem.cacheDirectory + "tiles/";
+
+export const version = Constants?.manifest?.version ?? "1.0.0";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,13 +1,17 @@
 import Constants from "expo-constants";
 import * as FileSystem from "expo-file-system";
-import { StatusBar } from "react-native";
+//import { Platform } from "react-native";
 
 export const baseUrl: string =
 	Constants?.manifest?.extra?.uri ??
 	"http://berry-picker-tracker.cs.helsinki.fi:88";
 
-export const statusBarHeight: number =
-	StatusBar.currentHeight ?? Constants.statusBarHeight;
+// This one is needed for the android build
+// export const statusBarHeight: number =
+// 	Platform.OS === "ios" ? Constants.statusBarHeight : 0;
+
+// This one is needed for the Expo Go
+export const statusBarHeight: number = Constants.statusBarHeight;
 
 export const tileCacheDirectory = FileSystem.cacheDirectory + "tiles/";
 

--- a/src/reducers/user-reducer.ts
+++ b/src/reducers/user-reducer.ts
@@ -2,6 +2,7 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import type { AppDispatch, ReduxState } from "../store";
 import { createNewUser } from "../requests";
 import { User } from "../types";
+import { restartBackgroundUpdate } from "../utils/location-tracking";
 
 const initialState: User = {
 	userId: null,
@@ -18,7 +19,6 @@ const userSlice = createSlice({
 			return { ...state, userId: action.payload };
 		},
 		setTrackingInterval(state, action: PayloadAction<number>) {
-			console.log("Setting new trackingInterval to", action.payload);
 			return { ...state, trackingInterval: action.payload };
 		},
 		setSendingInterval(state, action: PayloadAction<number>) {
@@ -74,17 +74,26 @@ export const resetUser = () => {
 };
 
 /**
- * Changing tracking/sending interval in the settings (src/screens/settings-screen.tsx).
- * Props: newInterval and if the change is the sending or tracking interval
- * @returns dispatch method to update tracking/sending interval.
+ * Changing waypoint tracking interval in the settings (src/screens/settings-screen.tsx).
+ * @param newInterval new tracking interval in seconds
+ * @returns dispatch method to update tracking interval.
  */
-export const setInterval = (newInterval: number, isTracking: boolean) => {
-	if (isTracking) {
-		return async (dispatch: AppDispatch) => {
-			dispatch(setTrackingInterval(newInterval));
-		};
-	}
+export const changeTrackingInterval = (newInterval: number) => {
 	return async (dispatch: AppDispatch) => {
+		console.log(`\nSetting new trackingInterval to ${newInterval / 1000} s`);
+		dispatch(setTrackingInterval(newInterval));
+		restartBackgroundUpdate(newInterval);
+	};
+};
+
+/**
+ * Changing waypoint sending interval to server in the settings (src/screens/settings-screen.tsx).
+ * @param newInterval new sending interval in seconds
+ * @returns dispatch method to update sending interval.
+ */
+export const changeSendingInterval = (newInterval: number) => {
+	return async (dispatch: AppDispatch) => {
+		console.log(`\nSetting new sendingInterval to ${newInterval / 1000} s\n`);
 		dispatch(setSendingInterval(newInterval));
 	};
 };
@@ -111,6 +120,8 @@ export const changeDefaultSettings = () => {
 		const userId = getState().user.userId;
 		console.log("Setting reseted to default");
 		dispatch(setDefaultSettings(userId));
+		const trackingInterval = getState().user.trackingInterval;
+		restartBackgroundUpdate(trackingInterval);
 	};
 };
 

--- a/src/reducers/user-reducer.ts
+++ b/src/reducers/user-reducer.ts
@@ -5,7 +5,7 @@ import { User } from "../types";
 
 const initialState: User = {
 	userId: null,
-	trackingInterval: 2500,
+	trackingInterval: 5000,
 	sendingInterval: 15000,
 	mapLifetime: 48,
 	offlineMode: false,
@@ -26,11 +26,9 @@ const userSlice = createSlice({
 			return { ...state, sendingInterval: action.payload };
 		},
 		setMapLifetime(state, action: PayloadAction<number>) {
-			console.log("Map lifetime changed into", action.payload);
 			return { ...state, mapLifetime: action.payload };
 		},
 		setDefaultSettings(_state, action: PayloadAction<string | null>) {
-			console.log("Setting reseted", action.payload);
 			return { ...initialState, userId: action.payload };
 		},
 	},
@@ -98,6 +96,7 @@ export const setInterval = (newInterval: number, isTracking: boolean) => {
  */
 export const changeMapLifetime = (newLifetime: number) => {
 	return async (dispatch: AppDispatch) => {
+		console.log(`Map cache lifetime changed into ${newLifetime} hours`);
 		dispatch(setMapLifetime(newLifetime));
 	};
 };
@@ -110,6 +109,7 @@ export const changeMapLifetime = (newLifetime: number) => {
 export const changeDefaultSettings = () => {
 	return async (dispatch: AppDispatch, getState: () => ReduxState) => {
 		const userId = getState().user.userId;
+		console.log("Setting reseted to default");
 		dispatch(setDefaultSettings(userId));
 	};
 };

--- a/src/reducers/user-reducer.ts
+++ b/src/reducers/user-reducer.ts
@@ -7,6 +7,8 @@ const initialState: User = {
 	userId: null,
 	trackingInterval: 2500,
 	sendingInterval: 15000,
+	mapLifetime: 48,
+	offlineMode: false,
 };
 const userSlice = createSlice({
 	name: "user",
@@ -23,11 +25,24 @@ const userSlice = createSlice({
 			console.log("Setting new sendingInterval to", action.payload);
 			return { ...state, sendingInterval: action.payload };
 		},
+		setMapLifetime(state, action: PayloadAction<number>) {
+			console.log("Map lifetime changed into", action.payload);
+			return { ...state, mapLifetime: action.payload };
+		},
+		setDefaultSettings(_state, action: PayloadAction<string | null>) {
+			console.log("Setting reseted", action.payload);
+			return { ...initialState, userId: action.payload };
+		},
 	},
 });
 
-export const { setUser, setTrackingInterval, setSendingInterval } =
-	userSlice.actions;
+export const {
+	setUser,
+	setTrackingInterval,
+	setSendingInterval,
+	setMapLifetime,
+	setDefaultSettings,
+} = userSlice.actions;
 
 /**
  * Function to identify user. Creates new user by using http request unless
@@ -61,7 +76,7 @@ export const resetUser = () => {
 };
 
 /**
- * Changing tracking/sedning interval in the settings (src/screens/settings-screen.tsx).
+ * Changing tracking/sending interval in the settings (src/screens/settings-screen.tsx).
  * Props: newInterval and if the change is the sending or tracking interval
  * @returns dispatch method to update tracking/sending interval.
  */
@@ -73,6 +88,29 @@ export const setInterval = (newInterval: number, isTracking: boolean) => {
 	}
 	return async (dispatch: AppDispatch) => {
 		dispatch(setSendingInterval(newInterval));
+	};
+};
+
+/**
+ * Change map tile cache lifetime in the settings
+ * @param newLifetime in hours
+ * @returns dispatch method to update map life time
+ */
+export const changeMapLifetime = (newLifetime: number) => {
+	return async (dispatch: AppDispatch) => {
+		dispatch(setMapLifetime(newLifetime));
+	};
+};
+
+/**
+ * Change default user settings such as intervals and map life time in the settings.
+ * User ID remains the same.
+ * @returns dispatch method to change default settings
+ */
+export const changeDefaultSettings = () => {
+	return async (dispatch: AppDispatch, getState: () => ReduxState) => {
+		const userId = getState().user.userId;
+		dispatch(setDefaultSettings(userId));
 	};
 };
 

--- a/src/screens/map-screen.tsx
+++ b/src/screens/map-screen.tsx
@@ -1,6 +1,5 @@
 import { View, StyleSheet } from "react-native";
 
-import AppHeader from "../components/app-header";
 import MapViewContainer from "../components/map-view-container";
 import RouteButtonContainer from "../components/route-button-container";
 import InfoContainer from "../components/info-container";
@@ -9,7 +8,6 @@ import NavigatorTab from "../components/navigator-tab";
 const MapScreen = () => {
 	return (
 		<View style={styles.container}>
-			<AppHeader name={"Berry picker tracker"} />
 			<MapViewContainer />
 			<RouteButtonContainer />
 			<InfoContainer />

--- a/src/screens/settings-screen.tsx
+++ b/src/screens/settings-screen.tsx
@@ -56,6 +56,9 @@ export const SettingScreen = () => {
 							deleteTileCacheDirectory();
 							makeTileCacheDirectory();
 						}
+						if (target === "settings") {
+							await dispatch(changeDefaultSettings());
+						}
 					},
 				},
 			]
@@ -187,16 +190,6 @@ export const SettingScreen = () => {
 					),
 				},
 				{
-					title: "Reset default settings",
-					renderAccessory: () => (
-						<Button
-							title="RESET"
-							onPress={() => dispatch(changeDefaultSettings())}
-							color="dimgrey"
-						/>
-					),
-				},
-				{
 					title: "Reset UserID",
 					titleStyle: {
 						color: "red",
@@ -208,6 +201,16 @@ export const SettingScreen = () => {
 								routeActive ? alertRouteIsActive() : alertOnReset("UserID")
 							}
 							color="red"
+						/>
+					),
+				},
+				{
+					title: "Reset settings to default",
+					renderAccessory: () => (
+						<Button
+							title="RESET"
+							onPress={() => alertOnReset("settings")}
+							color="dimgrey"
 						/>
 					),
 				},

--- a/src/screens/settings-screen.tsx
+++ b/src/screens/settings-screen.tsx
@@ -12,7 +12,8 @@ import {
 	changeMapLifetime,
 	identifyUser,
 	resetUser,
-	setInterval,
+	changeTrackingInterval,
+	changeSendingInterval,
 } from "../reducers/user-reducer";
 import {
 	deleteTileCacheDirectory,
@@ -32,6 +33,7 @@ export const SettingScreen = () => {
 			state.user.mapLifetime,
 		]
 	);
+	const routeActive = useTypedSelector((state) => state.route.active);
 
 	const dispatch = useTypedDispatch();
 
@@ -55,6 +57,18 @@ export const SettingScreen = () => {
 							makeTileCacheDirectory();
 						}
 					},
+				},
+			]
+		);
+	};
+
+	const alertRouteIsActive = () => {
+		Alert.alert(
+			"Route is currently active",
+			"UserID can not be reseted while route is active. End route route first and try again",
+			[
+				{
+					text: "OK",
 				},
 			]
 		);
@@ -101,7 +115,7 @@ export const SettingScreen = () => {
 							initValue={currTrack.toString() + " s"}
 							initValueTextStyle={styles.initValueStyle}
 							onChange={async (option: { label: number }) => {
-								await dispatch(setInterval(option.label, true));
+								await dispatch(changeTrackingInterval(option.label));
 							}}
 						/>
 					),
@@ -114,7 +128,7 @@ export const SettingScreen = () => {
 							initValue={currSend.toString() + " s"}
 							initValueTextStyle={styles.initValueStyle}
 							onChange={async (option: { label: number }) => {
-								await dispatch(setInterval(option.label, false));
+								await dispatch(changeSendingInterval(option.label));
 							}}
 						/>
 					),
@@ -190,7 +204,9 @@ export const SettingScreen = () => {
 					renderAccessory: () => (
 						<Button
 							title="RESET"
-							onPress={() => alertOnReset("UserID")}
+							onPress={() =>
+								routeActive ? alertRouteIsActive() : alertOnReset("UserID")
+							}
 							color="red"
 						/>
 					),

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,8 +1,8 @@
 const theme = {
 	colors: {
-		textPrimary: "black",
+		textPrimary: "dimgrey",
 		textSecondary: "white",
-		buttonBackgroundColor: "white",
+		buttonBackgroundColor: "#b0c4de",
 		primaryBackgroundColor: "#008b8b",
 	},
 	fontSizes: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,4 +23,6 @@ export interface User {
 	userId: string | null;
 	trackingInterval: number;
 	sendingInterval: number;
+	mapLifetime: number;
+	offlineMode: boolean;
 }

--- a/src/utils/location-tracking.ts
+++ b/src/utils/location-tracking.ts
@@ -59,8 +59,9 @@ export const startBackgroundUpdate = async (trackingInterval: number) => {
 		timeInterval: trackingInterval,
 		showsBackgroundLocationIndicator: true,
 		foregroundService: {
-			notificationTitle: "Route tracking is active",
-			notificationBody: "Your current location will be tracked on a background",
+			notificationTitle: "Berry picker tracker is running on a background",
+			notificationBody:
+				"You must end current route tracking in order to close the application",
 			notificationColor: "#008b8b",
 		},
 	});

--- a/src/utils/location-tracking.ts
+++ b/src/utils/location-tracking.ts
@@ -10,8 +10,7 @@ const locationTaskOptions = {
 	showsBackgroundLocationIndicator: true,
 	foregroundService: {
 		notificationTitle: "Berry picker tracker is running on a background",
-		notificationBody:
-			"You must end current route tracking in order to close the application",
+		notificationBody: "End current route tracking in order to close the app",
 		notificationColor: "#008b8b",
 	},
 };

--- a/src/utils/location-tracking.ts
+++ b/src/utils/location-tracking.ts
@@ -4,6 +4,17 @@ import { storeAndSendWaypoints } from "../reducers/waypoint-reducer";
 import { AppDispatch } from "../store";
 
 const TRACK_WAYPOINTS = "track_waypoints";
+const locationTaskOptions = {
+	accuracy: Location.Accuracy.BestForNavigation, //NB! Altering this may affect for the interval
+	activityType: Location.ActivityType.Fitness,
+	showsBackgroundLocationIndicator: true,
+	foregroundService: {
+		notificationTitle: "Berry picker tracker is running on a background",
+		notificationBody:
+			"You must end current route tracking in order to close the application",
+		notificationColor: "#008b8b",
+	},
+};
 
 /**
  * Defines background task for location tracking. When task is running
@@ -54,17 +65,27 @@ export const requestPermissions = async () => {
  */
 export const startBackgroundUpdate = async (trackingInterval: number) => {
 	await Location.startLocationUpdatesAsync(TRACK_WAYPOINTS, {
-		accuracy: Location.Accuracy.BestForNavigation, //NB! Altering this may affect for the interval
-		activityType: Location.ActivityType.Fitness,
+		...locationTaskOptions,
 		timeInterval: trackingInterval,
-		showsBackgroundLocationIndicator: true,
-		foregroundService: {
-			notificationTitle: "Berry picker tracker is running on a background",
-			notificationBody:
-				"You must end current route tracking in order to close the application",
-			notificationColor: "#008b8b",
-		},
 	});
+};
+
+export const restartBackgroundUpdate = async (trackingInterval: number) => {
+	const trackingActive = await Location.hasStartedLocationUpdatesAsync(
+		TRACK_WAYPOINTS
+	);
+	if (trackingActive) {
+		console.log(
+			`Restarting background location updates with new tracking interval ${
+				trackingInterval / 1000
+			} s\n`
+		);
+		await Location.stopLocationUpdatesAsync(TRACK_WAYPOINTS);
+		await Location.startLocationUpdatesAsync(TRACK_WAYPOINTS, {
+			...locationTaskOptions,
+			timeInterval: trackingInterval,
+		});
+	}
 };
 
 /**


### PR DESCRIPTION
Very badly named branch. Early idea was to restart route tracking on app launch if it has been shutdown while tracking is active. However, it looks like that while background location tracking is active, the application can not be completely shutdown so the user has to anyway end route tracking in order to fully shutdown the app. Instead of that, the following changes has been made:

* Add `restartBackgroundUpdate` function to `utils/location-tracking` file so that when user can change tracking interval while route tracking is active and the change will be applied immediately
* Removed app header from the Navigation screen and yet again investigated issues with statusbar height. It looks like that the statusbar height needs to be set on 0 on android builds, but needs to be adjusted on Expo Go... Currently there are two options at the `contants.ts` to choose, but investigating needs to be continued
* Added new parameters for the `user-reducer` such as `mapLifetime`, `offlineMode` and added necessary reducers and action creaters
* Added `reset default settings` option to setting screen and possibility to change mapLifetime state through the settings
* Added new alert check so that userID can not be reseted during the route is active at the setting screen
* Did some minor improvements for the application appearance