### PR TITLE
Copy userID to clipboard

### DIFF
--- a/src/screens/settings-screen.tsx
+++ b/src/screens/settings-screen.tsx
@@ -5,6 +5,8 @@ import {
 	StyleSheet,
 	Text,
 	View,
+	TouchableOpacity,
+	Clipboard,
 } from "react-native";
 import { useTypedDispatch, useTypedSelector } from "../store";
 import {
@@ -25,6 +27,10 @@ import ModalSelector from "react-native-modal-selector";
 import { statusBarHeight, version } from "../constants";
 
 export const SettingScreen = () => {
+	// Some of the components are old and give unnecessary warnings,
+	// so warnings are disabled. Enable by commenting:
+	console.warn = () => {};
+
 	const [userId, currTrack, currSend, mapLifetime] = useTypedSelector(
 		(state) => [
 			state.user.userId,
@@ -77,6 +83,15 @@ export const SettingScreen = () => {
 		);
 	};
 
+	const copyToClipboard = (target: string | null) => {
+		if (target !== null) {
+			console.log(`Copied ${target} to clipboard`);
+			Clipboard.setString(target);
+		} else {
+			console.log(`Empty userID`);
+		}
+	};
+
 	let index = 0;
 	const trackFreq = [
 		{ key: index++, component: <Text>1 second</Text>, label: 1000 },
@@ -107,8 +122,7 @@ export const SettingScreen = () => {
 		{
 			type: "SECTION",
 			header: "Navigation".toUpperCase(),
-			footer:
-				"Change tracking and sending frequencies to save battery life and turn the app to offline mode",
+			footer: "Change frequencies to save battery life",
 			rows: [
 				{
 					title: "Waypoint tracking frequency",
@@ -145,8 +159,7 @@ export const SettingScreen = () => {
 		{
 			type: "SECTION",
 			header: "Map cache".toUpperCase(),
-			footer:
-				"Delete cached map tiles to clear space and change their lifetime",
+			footer: "Delete cached map tiles to clear space",
 			rows: [
 				{
 					title: "Maptile lifetime",
@@ -179,14 +192,14 @@ export const SettingScreen = () => {
 		{
 			type: "SECTION",
 			header: "User information".toUpperCase(),
-			footer: "Check, copy and reset your UserID or restore default settings",
+			footer: "Click your UserID to copy it",
 			rows: [
 				{
 					title: "UserID",
 					renderAccessory: () => (
-						<Text style={{ color: "dimgrey", fontSize: 12 }}>
-							{`${userId ? userId : "not stored yet"}`}
-						</Text>
+						<TouchableOpacity onPress={() => copyToClipboard(userId)}>
+							<Text style={{ color: "dimgrey", fontSize: 12 }}>{userId}</Text>
+						</TouchableOpacity>
 					),
 				},
 				{
@@ -204,13 +217,21 @@ export const SettingScreen = () => {
 						/>
 					),
 				},
+			],
+		},
+		{
+			type: "SECTION",
+			rows: [
 				{
 					title: "Reset settings to default",
+					titleStyle: {
+						color: "red",
+					},
 					renderAccessory: () => (
 						<Button
 							title="RESET"
 							onPress={() => alertOnReset("settings")}
-							color="dimgrey"
+							color="red"
 						/>
 					),
 				},


### PR DESCRIPTION
Simple change to copy UserID to clipboard. Set up to allow users to share userIDs for future tracking implementation.

Also now ignoring warnings from a few packages on the settings-screen. react-native-settings-screen and react-native Clipboard are old and give warnings to update them. They are not able to be updated in the current expo build. If debugging, enable warnings.