### PR TITLE
Wip search user route screen

### DIFF
--- a/src/components/find-user-route-button.tsx
+++ b/src/components/find-user-route-button.tsx
@@ -3,15 +3,15 @@ import Icon from "react-native-vector-icons/FontAwesome";
 import { Link } from "react-router-native";
 import NaviTabStyles from "../navi-tab-styles";
 
-const CoffeeButton = ({ text }: { text: string }): JSX.Element => {
+const FindUserButton = ({ text }: { text: string }): JSX.Element => {
 	return (
-		<Link to="/coffee" underlayColor="#ffffff00">
+		<Link to="/findroute" underlayColor="#ffffff00">
 			<View style={NaviTabStyles.buttonStyle}>
-				<Icon name="coffee" style={NaviTabStyles.iconStyle} />
+				<Icon name="location-arrow" style={NaviTabStyles.iconStyle} />
 				<Text style={NaviTabStyles.textStyle}>{text}</Text>
 			</View>
 		</Link>
 	);
 };
 
-export default CoffeeButton;
+export default FindUserButton;

--- a/src/components/find-user-route-container.tsx
+++ b/src/components/find-user-route-container.tsx
@@ -1,0 +1,87 @@
+import { View, StyleSheet, Dimensions } from "react-native";
+import MapView, { Marker, Polyline, UrlTile } from "react-native-maps";
+
+import { baseUrl, tileCacheDirectory } from "../constants";
+import { useTypedSelector } from "../store";
+import { usersLocationInfo } from "../types";
+
+const styles = StyleSheet.create({
+	map: {
+		width: Dimensions.get("window").width * 0.9,
+		height: Dimensions.get("window").height * 0.6,
+	},
+});
+
+/**
+ * To be added.
+ */
+const FindUserRouteContainer = ({
+	usersWaypoints,
+	usersLatestWaypoint,
+}: usersLocationInfo): JSX.Element => {
+	const mapLifetime = useTypedSelector((state) => state.user.mapLifetime);
+
+	return (
+		<View>
+			<MapView
+				mapType={"none"}
+				style={styles.map}
+				showsUserLocation={true}
+				initialRegion={{
+					latitude: usersLatestWaypoint
+						? usersLatestWaypoint.latitude
+						: 60.204662,
+					longitude: usersLatestWaypoint
+						? usersLatestWaypoint.longitude
+						: 24.962535,
+					latitudeDelta: 0.05,
+					longitudeDelta: 0.05,
+				}}
+			>
+				<UrlTile
+					urlTemplate={`${baseUrl}/nlsapi/{z}/{y}/{x}`}
+					tileSize={256}
+					maximumZ={19}
+					zIndex={-3}
+					tileCachePath={tileCacheDirectory}
+					tileCacheMaxAge={mapLifetime * 3600}
+					offlineMode={false}
+				/>
+				<Polyline
+					coordinates={usersWaypoints}
+					strokeColor="green"
+					strokeWidth={4}
+					zIndex={2}
+				/>
+				<Polyline
+					coordinates={usersWaypoints}
+					strokeColor="black"
+					strokeWidth={8}
+					zIndex={1}
+				/>
+				<Marker
+					title={
+						usersLatestWaypoint
+							? "Latest waypoint timestamp"
+							: "Latest waypoint is not available"
+					}
+					description={
+						usersLatestWaypoint
+							? usersLatestWaypoint.ts.toString()
+							: "Update search a bit later"
+					}
+					coordinate={{
+						latitude: usersLatestWaypoint
+							? usersLatestWaypoint.latitude
+							: 60.204662,
+						longitude: usersLatestWaypoint
+							? usersLatestWaypoint.longitude
+							: 24.962535,
+					}}
+				/>
+			</MapView>
+		</View>
+	);
+};
+
+export default FindUserRouteContainer;

--- a/src/components/find-user-route-container.tsx
+++ b/src/components/find-user-route-container.tsx
@@ -13,7 +13,10 @@ const styles = StyleSheet.create({
 });
 
 /**
- * To be added.
+ * Visualizes topomap using NLS tiles and draws a users route between
+ * latest route waypoints. Show marker at the latest waypoint location.
+ * Timestamp will be shown when the marker has been pressed.
+ * Initial region will be shown at the Kumpula kampus if list of users waypoint is empty.
  */
 const FindUserRouteContainer = ({
 	usersWaypoints,

--- a/src/components/navigator-tab.tsx
+++ b/src/components/navigator-tab.tsx
@@ -1,6 +1,6 @@
 import { View, StyleSheet } from "react-native";
 import MapButton from "./map-button";
-import CoffeeButton from "./coffee-button";
+import FindUserRouteButton from "./find-user-route-button";
 import SettingsButton from "./settings-button";
 
 const styles = StyleSheet.create({
@@ -28,7 +28,7 @@ const NavigatorTab = (): JSX.Element => {
 	return (
 		<View style={styles.navigatorTab}>
 			<MapButton text="Map" />
-			<CoffeeButton text="Coffee" />
+			<FindUserRouteButton text="Find" />
 			<SettingsButton text="Settings" />
 		</View>
 	);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import { useTypedDispatch } from "./store";
 import { identifyUser } from "./reducers/user-reducer";
 import MapScreen from "./screens/map-screen";
 import SettingsScreen from "./screens/settings-screen";
-import CoffeeScreen from "./screens/coffee-screen";
+import FindUserRouteScreen from "./screens/find-user-route-screen";
 import NavigatorTab from "./components/navigator-tab";
 
 import {
@@ -33,7 +33,7 @@ const Main = () => {
 			<Routes>
 				<Route path="/" element={<MapScreen />} />
 				<Route path="/settings" element={<SettingsScreen />} />
-				<Route path="/coffee" element={<CoffeeScreen />} />
+				<Route path="/findroute" element={<FindUserRouteScreen />} />
 				<Route path="*" element={<Navigate to="/" replace />} />
 			</Routes>
 		</View>

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -1,4 +1,4 @@
-import { Waypoint } from "./types";
+import { Waypoint, WaypointFromServer } from "./types";
 import { baseUrl } from "./constants";
 
 export const createNewUser = async () => {
@@ -78,6 +78,28 @@ export const deactivateExistingRoute = async (routeId: string) => {
 		const response = await fetch(url, settings);
 		const data = await response.json();
 		console.log(`Route id ${data.id} active status set to: ${data.active}`);
+	} catch (error) {
+		console.log(error);
+	}
+};
+
+export const getUsersLatestRoute = async (userId: string) => {
+	const url = `${baseUrl}/get-users-latest-route/`;
+	const settings = {
+		method: "GET",
+		headers: {
+			Accept: "application/json",
+			"Content-Type": "application/json",
+			"user-id": userId,
+		},
+	};
+	try {
+		const response = await fetch(url, settings);
+		const data = await response.json();
+		const routeId: string = data[0];
+		const active: boolean = data[1];
+		const waypoints: WaypointFromServer[] = data[2];
+		return { routeId, active, waypoints };
 	} catch (error) {
 		console.log(error);
 	}

--- a/src/screens/coffee-screen.tsx
+++ b/src/screens/coffee-screen.tsx
@@ -1,13 +1,128 @@
-import { View } from "react-native";
-import Icon from "react-native-vector-icons/FontAwesome5";
+import { useState } from "react";
+import { View, Text, TextInput, StyleSheet, Dimensions } from "react-native";
+import FindUserRouteContainer from "../components/find-user-route-container";
+import RouteButton from "../components/route-button";
+import { getUsersLatestRoute } from "../requests";
+import { Waypoint, WaypointFromServer } from "../types";
+import { statusBarHeight } from "../constants";
 
 const CoffeeScreen = () => {
+	const [userId, setUserId] = useState<string>("");
+	const [usersWaypoints, setUsersWaypoints] = useState<null | Waypoint[]>(null);
+	const [infoText, setInfoText] = useState<string>(
+		"Search users latest route by typing user ID"
+	);
+
+	const findUserRoute = async () => {
+		// Just temporary quick fix to re-adjust initial map region while updating the search
+		setUsersWaypoints(null);
+
+		console.log(`Finding user with id ${userId}...`);
+		const data = await getUsersLatestRoute(userId);
+		if (data !== undefined) {
+			const waypoints: Waypoint[] = data.waypoints.map(
+				(waypoint: WaypointFromServer) => {
+					return {
+						...waypoint,
+						routeId: waypoint.route_id,
+					};
+				}
+			);
+			setInfoText(
+				data.active ? "User route is active" : "User has no active route"
+			);
+			setUsersWaypoints(waypoints);
+			console.log(
+				`...Users route id: ${data.routeId} found. Route is: ${data.active}. Number of waypoints stored: ${data.waypoints.length}`
+			);
+		} else {
+			console.log("...Failed");
+		}
+	};
+
 	return (
-		<View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
-			<Icon name="coffee" size={60} color="lightblue" />
-			<Icon name="hamburger" size={60} color="brown" />
+		<View style={styles.container}>
+			<View style={styles.titleContainer}>
+				<Text style={styles.headerStyle}>Find users latest route</Text>
+			</View>
+			<View style={styles.inputContainer}>
+				<TextInput
+					style={styles.input}
+					onChangeText={setUserId}
+					value={userId}
+					placeholder="user-ID"
+				/>
+				<RouteButton
+					onPress={findUserRoute}
+					text={usersWaypoints ? "Update" : "Search"}
+				/>
+			</View>
+			<Text style={styles.textStyle}>{infoText}</Text>
+			{usersWaypoints ? (
+				<FindUserRouteContainer
+					usersWaypoints={usersWaypoints}
+					usersLatestWaypoint={usersWaypoints[usersWaypoints.length - 1]}
+				/>
+			) : (
+				<View style={styles.mapBox} />
+			)}
 		</View>
 	);
 };
+const styles = StyleSheet.create({
+	container: {
+		flex: 0,
+		width: "95%",
+		height: Dimensions.get("window").height - 75,
+		alignItems: "center",
+		justifyContent: "center",
+		flexDirection: "column",
+		top: statusBarHeight,
+		paddingLeft: 10,
+		paddingRight: 10,
+	},
+	titleContainer: {
+		flex: 1,
+		width: "100%",
+
+		justifyContent: "center",
+		flexDirection: "row",
+		borderBottomColor: "lightgrey",
+		borderBottomWidth: 1.5,
+	},
+	headerStyle: {
+		fontSize: 20,
+		color: "dimgrey",
+		alignContent: "center",
+		alignSelf: "center",
+	},
+	input: {
+		width: "70%",
+		borderWidth: 1,
+		padding: 15,
+		borderRadius: 10,
+		textAlign: "center",
+		height: 50,
+		margin: 5,
+	},
+	inputContainer: {
+		alignSelf: "center",
+		flexDirection: "row",
+		padding: 10,
+		width: "95%",
+	},
+	textStyle: {
+		fontSize: 15,
+		color: "dimgrey",
+		padding: 10,
+		alignSelf: "center",
+	},
+	mapBox: {
+		width: Dimensions.get("window").width * 0.9,
+		height: Dimensions.get("window").height * 0.6,
+		backgroundColor: "lightgrey",
+		opacity: 0.7,
+	},
+});
 
 export default CoffeeScreen;

--- a/src/screens/find-route-screen.tsx
+++ b/src/screens/find-route-screen.tsx
@@ -6,15 +6,20 @@ import { getUsersLatestRoute } from "../requests";
 import { Waypoint, WaypointFromServer } from "../types";
 import { statusBarHeight } from "../constants";
 
-const CoffeeScreen = () => {
+const FindRouteScreen = () => {
 	const [userId, setUserId] = useState<string>("");
 	const [usersWaypoints, setUsersWaypoints] = useState<null | Waypoint[]>(null);
 	const [infoText, setInfoText] = useState<string>(
-		"Search users latest route by typing user ID"
+		"Search users latest route by typing userID"
 	);
 
+	/**
+	 * Searches users latest route from the server with user ID.
+	 * Updates `usersWaypoint` state with list of latest route waypoints
+	 * sets corresponding info text depending wheter latest route is active or not.
+	 */
 	const findUserRoute = async () => {
-		// Just temporary quick fix to re-adjust initial map region while updating the search
+		// To re-adjust initial map region while updating the search
 		setUsersWaypoints(null);
 
 		console.log(`Finding user with id ${userId}...`);
@@ -33,7 +38,7 @@ const CoffeeScreen = () => {
 			);
 			setUsersWaypoints(waypoints);
 			console.log(
-				`...Users route id: ${data.routeId} found. Route is: ${data.active}. Number of waypoints stored: ${data.waypoints.length}`
+				`...Users route ID: ${data.routeId} found. Route is: ${data.active}. Number of waypoints stored: ${data.waypoints.length}`
 			);
 		} else {
 			console.log("...Failed");
@@ -50,7 +55,7 @@ const CoffeeScreen = () => {
 					style={styles.input}
 					onChangeText={setUserId}
 					value={userId}
-					placeholder="user-ID"
+					placeholder="userID"
 				/>
 				<RouteButton
 					onPress={findUserRoute}
@@ -125,4 +130,4 @@ const styles = StyleSheet.create({
 	},
 });
 
-export default CoffeeScreen;
+export default FindRouteScreen;

--- a/src/screens/find-user-route-screen.tsx
+++ b/src/screens/find-user-route-screen.tsx
@@ -6,7 +6,7 @@ import { getUsersLatestRoute } from "../requests";
 import { Waypoint, WaypointFromServer } from "../types";
 import { statusBarHeight } from "../constants";
 
-const FindRouteScreen = () => {
+const FindUserRouteScreen = () => {
 	const [userId, setUserId] = useState<string>("");
 	const [usersWaypoints, setUsersWaypoints] = useState<null | Waypoint[]>(null);
 	const [infoText, setInfoText] = useState<string>(
@@ -130,4 +130,4 @@ const styles = StyleSheet.create({
 	},
 });
 
-export default FindRouteScreen;
+export default FindUserRouteScreen;

--- a/src/screens/settings-screen.tsx
+++ b/src/screens/settings-screen.tsx
@@ -8,7 +8,6 @@ import {
 	Linking,
 	TouchableOpacity,
 	Clipboard,
-
 } from "react-native";
 import { useTypedDispatch, useTypedSelector } from "../store";
 import {
@@ -225,6 +224,7 @@ export const SettingScreen = () => {
 		},
 		{
 			type: "SECTION",
+			header: "Default settings".toUpperCase(),
 			rows: [
 				{
 					title: "Reset settings to default",
@@ -280,6 +280,27 @@ export const SettingScreen = () => {
 							onPress={() =>
 								Linking.openURL(
 									"https://github.com/hy-ohtu-syksy-22-bpt/berry-picker-tracker-docs/blob/main/privacy_policies.md"
+								)
+							}
+						/>
+					),
+				},
+			],
+		},
+		{
+			type: "SECTION",
+			header: "Map legend".toUpperCase(),
+			footer:
+				"Download link to National Land Survey of Finland map legend information",
+			rows: [
+				{
+					title: "Download map legends",
+					renderAccessory: () => (
+						<Icon
+							name="chevron-right"
+							onPress={() =>
+								Linking.openURL(
+									"https://www.maanmittauslaitos.fi/sites/maanmittauslaitos.fi/files/attachments/2020/01/karttamerkkien_selitys.pdf"
 								)
 							}
 						/>

--- a/src/screens/settings-screen.tsx
+++ b/src/screens/settings-screen.tsx
@@ -29,6 +29,7 @@ import { statusBarHeight, version } from "../constants";
 export const SettingScreen = () => {
 	// Some of the components are old and give unnecessary warnings,
 	// so warnings are disabled. Enable by commenting:
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	console.warn = () => {};
 
 	const [userId, currTrack, currSend, mapLifetime] = useTypedSelector(

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,20 @@ export interface Waypoint {
 	ts: number;
 }
 
+export interface WaypointFromServer {
+	route_id: string | null;
+	latitude: number;
+	longitude: number;
+	mnc: string | null;
+	connection: string | null;
+	ts: number;
+}
+
+export interface usersLocationInfo {
+	usersWaypoints: Waypoint[];
+	usersLatestWaypoint: null | Waypoint;
+}
+
 export interface WaypointState {
 	routeId: string | null;
 	localWaypoints: Array<Waypoint>;


### PR DESCRIPTION
Replace Coffee screen with Find users route screen. Following changes:

* Several `coffee` related files and functions has been renamed in to `find user route` type.
* Create new request to get users latest route from the server
* Create new `map-view` component which displayes users latest route and points out latest waypoint with timestamp
* Find user screen has simple input field, info text and map-view after succesfull search

Current UI is quite preliminary and could be possibly cleaned along with other UI improvements.

Other modifications made:
* Add header to the reset settings at settings screen
* Add download link to map legends at settings screen