### PR TITLE
Wip fixing edge cases

### DIFF
--- a/src/reducers/route-reducer.ts
+++ b/src/reducers/route-reducer.ts
@@ -1,6 +1,10 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import type { AppDispatch, ReduxState } from "../store";
-import { startNewRoute, deactivateExistingRoute } from "../requests";
+import {
+	startNewRoute,
+	deactivateExistingRoute,
+	sendNewWaypoint,
+} from "../requests";
 import { Route, User } from "../types";
 import { setRouteId, initializeWaypoints } from "./waypoint-reducer";
 import {
@@ -62,8 +66,8 @@ export const startRoute = (user: User) => {
 
 /**
  * Function to deactivate route. Validates that user ID is not null and
- * makes http request to deactivate active route, initializes route state
- * and stops background location tracking.
+ * makes http request to send last waypoints, deactivate active route,
+ * initializes route state and stops background location tracking.
  * Route object `active`param will be se to false.
  * @param routeId
  * @returns dispatch method to reset route state
@@ -71,8 +75,10 @@ export const startRoute = (user: User) => {
 export const deactivateRoute = () => {
 	return async (dispatch: AppDispatch, getState: () => ReduxState) => {
 		const routeId = getState().route.routeId;
+		const pendingWaypoints = getState().waypoints.pendingWaypoints;
 		if (routeId !== null) {
 			console.log(`\nDeactivating route with id: ${routeId}`);
+			await sendNewWaypoint(pendingWaypoints);
 			await deactivateExistingRoute(routeId);
 			dispatch(setRoute(initialState));
 			dispatch(initializeWaypoints());

--- a/src/reducers/waypoint-reducer.ts
+++ b/src/reducers/waypoint-reducer.ts
@@ -54,13 +54,15 @@ export const {
 /**
  * Checks wheter route ID has been initialized. If so, gets location and MNC code and creates
  * a new waypoint object which will stored into localdevices `WaypointState`
- * Sends also waypoints to the server, if there are more than 5 pending waypoints
+ * Sends waypoints to server according to the sending interval.
  * @returns dispatch method to update `WaypointState`
  */
 export const storeAndSendWaypoints = () => {
 	return async (dispatch: AppDispatch, getState: () => ReduxState) => {
 		const routeId = getState().waypoints.routeId;
 		const pendingWaypoints = getState().waypoints.pendingWaypoints;
+		const sendingInterval = getState().user.sendingInterval;
+		const trackingInterval = getState().user.trackingInterval;
 		if (routeId !== null) {
 			const location = await Location.getLastKnownPositionAsync({});
 			const networkCode = await Cellular.getMobileNetworkCodeAsync();
@@ -83,8 +85,8 @@ export const storeAndSendWaypoints = () => {
 				dispatch(appendWaypoint(waypoint));
 			}
 		}
-		if (pendingWaypoints.length > 5) {
-			console.log(`\n${pendingWaypoints.length} waypoints send to the server`);
+		if (pendingWaypoints.length > ~~(sendingInterval / trackingInterval)) {
+			console.log(`\n${pendingWaypoints.length} waypoints sent to the server`);
 			await sendNewWaypoint(pendingWaypoints);
 			dispatch(resetPendingWaypoints());
 		}

--- a/src/reducers/waypoint-reducer.ts
+++ b/src/reducers/waypoint-reducer.ts
@@ -93,9 +93,10 @@ export const storeAndSendWaypoints = () => {
 		}
 
 		if (
-			pendingWaypoints.length >
+			isConnected &&
+			(pendingWaypoints.length >
 				~~(sendingInterval / trackingInterval) + 0.5 * sendTicker ** 1.4 ||
-			(wasOffline && isConnected)
+				wasOffline)
 		) {
 			const response: Response = (await sendNewWaypoint(
 				pendingWaypoints

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -57,8 +57,8 @@ export const sendNewWaypoint = async (pendingWaypoints: Array<Waypoint>) => {
 	};
 	try {
 		const response = await fetch(url, settings);
-		const data = await response.json();
-		return data;
+		//const data = await response.json();
+		return response;
 	} catch (error) {
 		console.log(error);
 	}


### PR DESCRIPTION
Added few fixes to the most obvious edge cases:
- When waypoints are sent, dont remove locally, if sending fails
- End route sends waypoints
- Sending interval is utilized
- After long disconnection, send waypoints instantly if there is a connection
- When tracking interval greater than sending interval, nothing breaks